### PR TITLE
Replace dark theme with black theme.

### DIFF
--- a/app/src/main/res/values/material3_colors_dark.xml
+++ b/app/src/main/res/values/material3_colors_dark.xml
@@ -6,7 +6,7 @@
     <color name="signal_dark_colorSecondaryContainer">#414659</color>
     <color name="signal_dark_colorSurface">#1B1C1F</color>
     <color name="signal_dark_colorSurfaceVariant">#303133</color>
-    <color name="signal_dark_colorBackground">#1B1C1F</color>
+    <color name="signal_dark_colorBackground">#000000</color>
     <color name="signal_dark_colorError">#FFB4A9</color>
     <color name="signal_dark_colorErrorContainer">#930006</color>
     <color name="signal_dark_colorOnPrimary">#1E2438</color>


### PR DESCRIPTION
I really hope this change will make it to the app because a lot of people including my self are begging to have the black instead of the dark, at least you can publish two releases at the same time (one with the black and one with the dark) I think it will be easier than maintaining 2 themes at the same app, and people will have the choice so no one will be forced to use a theme he does not like. Thank you for your time and i hope you will consider my thoughts on your exellent project.